### PR TITLE
Generate a `linkId` if `null` in end run request

### DIFF
--- a/apps/api/src/main/kotlin/org/nxcloudce/api/presentation/dto/RunDto.kt
+++ b/apps/api/src/main/kotlin/org/nxcloudce/api/presentation/dto/RunDto.kt
@@ -35,11 +35,18 @@ sealed class RunDto {
     override val meta: Map<String, String>,
     override val vcsContext: String?,
     val tasks: Collection<Task>,
-    val linkId: String,
+    val linkId: String?,
     val run: RunData,
     val projectGraph: String?,
     val hashedContributors: String?,
   ) : RunDto() {
+    companion object {
+      fun buildLinkId(): String {
+        val characters = ('A'..'Z') + ('a'..'z') + ('0'..'9')
+        return (1..10).map { characters.random() }.joinToString("")
+      }
+    }
+
     fun toRunRequest(): EndRunRequest.Run =
       EndRunRequest.Run(
         command = run.command,
@@ -54,7 +61,7 @@ sealed class RunDto {
         machineInfo = machineInfo,
         meta = meta,
         vcsContext = vcsContext,
-        linkId = linkId,
+        linkId = linkId ?: buildLinkId(),
         projectGraph = projectGraph,
         hashedContributors = hashedContributors,
       )

--- a/apps/api/src/test/kotlin/org/nxcloudce/api/presentation/controller/RunControllerTest.kt
+++ b/apps/api/src/test/kotlin/org/nxcloudce/api/presentation/controller/RunControllerTest.kt
@@ -89,38 +89,7 @@ class RunControllerTest {
         .header("Content-Type", "application/octet-stream")
         .body(
           gzipDto(
-            RunDto.End(
-              branch = null,
-              runGroup = "run-group",
-              ciExecutionId = null,
-              ciExecutionEnv = null,
-              MachineInfo(
-                machineId = "junit",
-                platform = "test",
-                version = "1",
-                cpuCores = 1,
-              ),
-              meta = mapOf("nxCloudVersion" to "123"),
-              vcsContext = null,
-              tasks =
-                listOf(
-                  buildTaskDto("1"),
-                  buildTaskDto("2"),
-                ),
-              linkId = "test-link-id",
-              projectGraph = null,
-              hashedContributors = null,
-              run =
-                RunDto.End.RunData(
-                  command = "nx run apps/api:test",
-                  startTime = LocalDateTime.now(),
-                  endTime = LocalDateTime.now().plusHours(1),
-                  branch = null,
-                  runGroup = null,
-                  inner = false,
-                  distributedExecutionId = null,
-                ),
-            ),
+            buildEndRunDto("test-link-id"),
           ),
         )
         .`when`()
@@ -191,6 +160,29 @@ class RunControllerTest {
         )
     }
 
+  @Test
+  fun `should end run and generate its link ID`() =
+    runTest {
+      val token = prepareWorkspaceAndAccessToken()
+
+      given()
+        .header("authorization", token)
+        .header("Content-Type", "application/octet-stream")
+        .body(
+          gzipDto(
+            buildEndRunDto(null),
+          ),
+        )
+        .`when`()
+        .post("/nx-cloud/runs/end")
+        .then()
+        .statusCode(200)
+        .body(
+          "status",
+          `is`("success"),
+        )
+    }
+
   private suspend fun prepareWorkspaceAndAccessToken(): String {
     val response =
       given()
@@ -229,6 +221,40 @@ class RunControllerTest {
         outputStream.toByteArray()
       }
     }
+
+  private fun buildEndRunDto(linkId: String? = null): RunDto.End =
+    RunDto.End(
+      branch = null,
+      runGroup = "run-group",
+      ciExecutionId = null,
+      ciExecutionEnv = null,
+      MachineInfo(
+        machineId = "junit",
+        platform = "test",
+        version = "1",
+        cpuCores = 1,
+      ),
+      meta = mapOf("nxCloudVersion" to "123"),
+      vcsContext = null,
+      tasks =
+        listOf(
+          buildTaskDto("1"),
+          buildTaskDto("2"),
+        ),
+      linkId = linkId,
+      projectGraph = null,
+      hashedContributors = null,
+      run =
+        RunDto.End.RunData(
+          command = "nx run apps/api:test",
+          startTime = LocalDateTime.now(),
+          endTime = LocalDateTime.now().plusHours(1),
+          branch = null,
+          runGroup = null,
+          inner = false,
+          distributedExecutionId = null,
+        ),
+    )
 
   private fun buildTaskDto(
     suffix: String,


### PR DESCRIPTION
- Fixes #26 