### PR TITLE
feat(helm-chart): add `server.database.dbName` to override default server's Mongo DB name

### DIFF
--- a/apps/helm-chart/src/templates/server/deployment.yaml
+++ b/apps/helm-chart/src/templates/server/deployment.yaml
@@ -62,7 +62,7 @@ spec:
           - name: QUARKUS_MONGODB_CONNECTION_STRING
             {{- include "nx-cloud-ce.server.database.connection-string" . | nindent 12 }}
           - name: QUARKUS_MONGODB_DATABASE
-            value: {{ .Values.server.name }}
+            value: {{  default .Values.server.name .Values.server.database.dbName }}
         {{- with .Values.server.envFrom }}
         envFrom:
           {{- toYaml . | nindent 10 }}

--- a/apps/helm-chart/src/values.yaml
+++ b/apps/helm-chart/src/values.yaml
@@ -105,6 +105,8 @@ server:
 
   # -- DB configuration when using external MongoDB
   database:
+    # @default -- `""` (defaults to server.name=server)
+    dbName: ""
     # @default -- `""` (defaults to mongodb.enabled=true)
     connectionStringSecretName: ""
     # @default -- `""` (defaults to mongodb.enabled=true)


### PR DESCRIPTION
- Fixes #127 