### PR TITLE
chore: fix JaCoCo report integration in SonarCloud

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,11 +85,10 @@ jobs:
         env:
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
-#      - name: SonarCloud Scan
-#        uses: SonarSource/sonarcloud-github-action@eb211723266fe8e83102bac7361f0a05c3ac1d1b # v3.0.0
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@383f7e52eae3ab0510c3cb0e7d9d150bbaeab838 # v3.1.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,8 +80,15 @@ jobs:
       - name: Setup build tools
         uses: ./.github/actions/setup-tools
 
-      - name: Run Test for affected projects
+      - name: Run Test for affected projects (PR)
+        if: github.ref != 'refs/heads/main'
         run: pnpm exec nx affected -t test
+        env:
+          NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+
+      - name: Run Test for all projects (main)
+        if: github.ref == 'refs/heads/main'
+        run: pnpm exec nx run-many --target=test --all
         env:
           NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 

--- a/apps/server/build.gradle.kts
+++ b/apps/server/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
   kotlin("plugin.allopen")
   id("io.quarkus")
   id("com.diffplug.spotless")
-  id("jacoco")
 }
 
 repositories {
@@ -69,15 +68,6 @@ java {
 
 tasks.withType<Test> {
   systemProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager")
-  finalizedBy("jacocoTestReport")
-}
-
-tasks.jacocoTestReport {
-  reports {
-    csv.required.set(false)
-    xml.required.set(true)
-    xml.outputLocation.set(layout.buildDirectory.file("reports/jacoco/jacoco.xml"))
-  }
 }
 
 allOpen {

--- a/libs/server/domain/build.gradle.kts
+++ b/libs/server/domain/build.gradle.kts
@@ -50,14 +50,15 @@ tasks.withType<Jar> {
 
 tasks.withType<Test> {
   systemProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager")
-  finalizedBy("jacocoTestReport")
-}
+  finalizedBy(tasks.jacocoTestReport)
 
-tasks.jacocoTestReport {
-  reports {
-    csv.required.set(false)
-    xml.required.set(true)
-    xml.outputLocation.set(layout.buildDirectory.file("reports/jacoco/jacoco.xml"))
+  configure<JacocoTaskExtension> {
+    excludeClassLoaders = listOf("*QuarkusClassLoader")
+    setDestinationFile(layout.buildDirectory.file("jacoco-quarkus.exec").get().asFile)
+  }
+
+  tasks.jacocoTestReport {
+    enabled = false
   }
 }
 

--- a/libs/server/persistence/build.gradle.kts
+++ b/libs/server/persistence/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
   kotlin("plugin.noarg")
   id("io.quarkus")
   id("com.diffplug.spotless")
-  id("jacoco")
 }
 
 repositories {
@@ -53,15 +52,6 @@ tasks.withType<Jar> {
 
 tasks.withType<Test> {
   systemProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager")
-  finalizedBy("jacocoTestReport")
-}
-
-tasks.jacocoTestReport {
-  reports {
-    csv.required.set(false)
-    xml.required.set(true)
-    xml.outputLocation.set(layout.buildDirectory.file("reports/jacoco/jacoco.xml"))
-  }
 }
 
 allOpen {

--- a/libs/server/storage/azure/build.gradle.kts
+++ b/libs/server/storage/azure/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
   kotlin("plugin.allopen")
   id("io.quarkus")
   id("com.diffplug.spotless")
-  id("jacoco")
 }
 
 repositories {
@@ -57,15 +56,6 @@ tasks.withType<Jar> {
 
 tasks.withType<Test> {
   systemProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager")
-  finalizedBy("jacocoTestReport")
-}
-
-tasks.jacocoTestReport {
-  reports {
-    csv.required.set(false)
-    xml.required.set(true)
-    xml.outputLocation.set(layout.buildDirectory.file("reports/jacoco/jacoco.xml"))
-  }
 }
 
 allOpen {

--- a/libs/server/storage/core/build.gradle.kts
+++ b/libs/server/storage/core/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
   kotlin("plugin.allopen")
   id("io.quarkus")
   id("com.diffplug.spotless")
-  id("jacoco")
 }
 
 repositories {
@@ -48,15 +47,6 @@ tasks.withType<Jar> {
 
 tasks.withType<Test> {
   systemProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager")
-  finalizedBy("jacocoTestReport")
-}
-
-tasks.jacocoTestReport {
-  reports {
-    csv.required.set(false)
-    xml.required.set(true)
-    xml.outputLocation.set(layout.buildDirectory.file("reports/jacoco/jacoco.xml"))
-  }
 }
 
 allOpen {

--- a/libs/server/storage/gcs/build.gradle.kts
+++ b/libs/server/storage/gcs/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
   kotlin("plugin.allopen")
   id("io.quarkus")
   id("com.diffplug.spotless")
-  id("jacoco")
 }
 
 repositories {
@@ -55,15 +54,6 @@ tasks.withType<Jar> {
 
 tasks.withType<Test> {
   systemProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager")
-  finalizedBy("jacocoTestReport")
-}
-
-tasks.jacocoTestReport {
-  reports {
-    csv.required.set(false)
-    xml.required.set(true)
-    xml.outputLocation.set(layout.buildDirectory.file("reports/jacoco/jacoco.xml"))
-  }
 }
 
 allOpen {

--- a/libs/server/storage/s3/build.gradle.kts
+++ b/libs/server/storage/s3/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
   kotlin("plugin.allopen")
   id("io.quarkus")
   id("com.diffplug.spotless")
-  id("jacoco")
 }
 
 repositories {
@@ -54,15 +53,6 @@ tasks.withType<Jar> {
 
 tasks.withType<Test> {
   systemProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager")
-  finalizedBy("jacocoTestReport")
-}
-
-tasks.jacocoTestReport {
-  reports {
-    csv.required.set(false)
-    xml.required.set(true)
-    xml.outputLocation.set(layout.buildDirectory.file("reports/jacoco/jacoco.xml"))
-  }
 }
 
 allOpen {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.projectKey=clementguillot_nx-cloud-ce
 sonar.organization=clementguillot
 sonar.kotlin.source.version=2.0
-sonar.coverage.jacoco.xmlReportPaths=**/build/reports/jacoco/jacoco.xml
+sonar.coverage.jacoco.xmlReportPaths=**/build/jacoco-report/jacoco.xml
 sonar.test.inclusions=**/src/test/kotlin/**/*.kt


### PR DESCRIPTION
- Fixes #232 
- Use incremental testing (`nx affected`) on PR
- Use full testing (`nx run-many .. --all`) on `main`