### PR TITLE
fix!: `ProjectGraph` are now completely stored in DB

### DIFF
--- a/apps/helm-chart/src/values.yaml
+++ b/apps/helm-chart/src/values.yaml
@@ -253,6 +253,17 @@ mongodb:
     # MANDATORY: enable this "experimental" feature to create a secret for service binding
     enabled: true
 
+  initdbScripts:
+    grant-role-to-server.js: |
+      use server
+      db.grantRolesToUser(
+        "server",
+        [
+          { role: "dbAdmin", db: "server" }
+        ],
+        { w: "majority", wtimeout: 5000 }
+      );
+
 ## Embedded NGINX configuration (Bitnami Helm Chart)
 nginx:
   # If `enabled`, Bitnami's chart is installed.

--- a/apps/server/project.json
+++ b/apps/server/project.json
@@ -14,7 +14,12 @@
     "build-native-sources": {
       "executor": "@jnxplus/nx-gradle:run-task",
       "options": {
-        "task": ["build", "-Dquarkus.package.type=native-sources"]
+        "task": [
+          "build",
+          "-Dquarkus.package.jar.enabled=false",
+          "-Dquarkus.native.enabled=true",
+          "-Dquarkus.native.sources-only=true"
+        ]
       },
       "outputs": ["{projectRoot}/build/native-sources"]
     },

--- a/apps/server/src/main/resources/application.yaml
+++ b/apps/server/src/main/resources/application.yaml
@@ -2,6 +2,9 @@ quarkus:
   http:
     port: 8080
     root-path: "/nx-cloud"
+  liquibase-mongodb:
+    change-log: db/change-log.yaml
+    migrate-at-start: true
   mongodb:
     database: nx-cloud-ce
   smallrye-openapi:

--- a/libs/server/domain/build.gradle.kts
+++ b/libs/server/domain/build.gradle.kts
@@ -54,7 +54,7 @@ tasks.withType<Test> {
 
   configure<JacocoTaskExtension> {
     excludeClassLoaders = listOf("*QuarkusClassLoader")
-    setDestinationFile(layout.buildDirectory.file("jacoco-quarkus.exec").get().asFile)
+    destinationFile = layout.buildDirectory.file("jacoco-quarkus.exec").get().asFile
   }
 
   tasks.jacocoTestReport {

--- a/libs/server/domain/src/main/kotlin/org/nxcloudce/server/domain/run/model/ProjectGraph.kt
+++ b/libs/server/domain/src/main/kotlin/org/nxcloudce/server/domain/run/model/ProjectGraph.kt
@@ -1,30 +1,45 @@
 package org.nxcloudce.server.domain.run.model
 
+/**
+ * Some type definitions can be found here:
+ * https://github.com/nrwl/nx/blob/master/packages/nx/src/config/project-graph.ts
+ * https://github.com/nrwl/nx/blob/master/packages/nx/src/config/workspace-json-project-json.ts
+ */
 data class ProjectGraph(
-  val nodes: Map<String, Project>?,
-  val dependencies: Map<String, List<Dependency>>?,
+  val nodes: Map<String, Project>,
+  val dependencies: Map<String, List<Dependency>>,
 ) {
   data class Project(
     val type: String,
     val name: String,
-    val data: Data,
+    val data: ProjectConfiguration,
   ) {
-    data class Data(
+    data class ProjectConfiguration(
       val root: String,
       val sourceRoot: String?,
-      val metadata: Map<String, Any>?,
-      val targets: Map<String, Target>,
+      val targets: Map<String, TargetConfiguration>?,
+      val metadata: ProjectMetadata?,
     ) {
-      data class Target(
+      data class TargetConfiguration(
         val executor: String?,
-        val dependsOn: Collection<String>?,
-        val options: Map<String, Any>?,
-        val configurations: Any?,
-        val parallelism: Boolean?,
-        val inputs: Collection<Any>?,
+        val command: String?,
         val outputs: Collection<String>?,
+        val dependsOn: Collection<String>?,
+        val inputs: Collection<Any>?,
+        val options: Any?,
+        val configurations: Map<String, Any>?,
         val defaultConfiguration: String?,
         val cache: Boolean?,
+        val parallelism: Boolean?,
+        val syncGenerators: Collection<String>?,
+        // missing `metadata?`
+      )
+
+      data class ProjectMetadata(
+        val description: String?,
+        val technologies: Collection<String>?,
+        val targetGroups: Map<String, Collection<String>>?,
+        // missing `owners?`
       )
     }
   }

--- a/libs/server/domain/src/test/kotlin/org/nxcloudce/server/domain/run/model/RunTest.kt
+++ b/libs/server/domain/src/test/kotlin/org/nxcloudce/server/domain/run/model/RunTest.kt
@@ -82,11 +82,32 @@ class RunTest {
               type = "application",
               name = "apps/server",
               data =
-                ProjectGraph.Project.Data(
+                ProjectGraph.Project.ProjectConfiguration(
                   root = "root",
                   sourceRoot = "root",
-                  metadata = emptyMap(),
-                  targets = emptyMap(),
+                  metadata =
+                    ProjectGraph.Project.ProjectConfiguration.ProjectMetadata(
+                      description = null,
+                      technologies = null,
+                      targetGroups = null,
+                    ),
+                  targets =
+                    mapOf(
+                      "apps/server" to
+                        ProjectGraph.Project.ProjectConfiguration.TargetConfiguration(
+                          executor = "nx",
+                          command = "nx build apps/server",
+                          outputs = null,
+                          dependsOn = null,
+                          inputs = null,
+                          options = null,
+                          configurations = null,
+                          defaultConfiguration = null,
+                          cache = null,
+                          parallelism = null,
+                          syncGenerators = null,
+                        ),
+                    ),
                 ),
             ),
         ),

--- a/libs/server/gateway/build.gradle.kts
+++ b/libs/server/gateway/build.gradle.kts
@@ -16,15 +16,20 @@ val javaVersion: String by project
 val quarkusPlatformGroupId: String by project
 val quarkusPlatformArtifactId: String by project
 val quarkusPlatformVersion: String by project
+val jacksonDatatypeJsr310Version: String by project
 val ktlintVersion: String by project
 val atriumVersion: String by project
 val mockkVersion: String by project
 val quarkusMockkVersion: String by project
 
 dependencies {
+  implementation(kotlin("stdlib-jdk8"))
+  implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+
   implementation(enforcedPlatform("$quarkusPlatformGroupId:$quarkusPlatformArtifactId:$quarkusPlatformVersion"))
   implementation("io.quarkus:quarkus-kotlin")
   implementation("io.quarkus:quarkus-mongodb-panache-kotlin")
+  implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonDatatypeJsr310Version")
 
   implementation(project(":libs:server:domain"))
   implementation(project(":libs:server:persistence"))

--- a/libs/server/gateway/src/main/kotlin/org/nxcloudce/server/gateway/infrastructure/JacksonProducers.kt
+++ b/libs/server/gateway/src/main/kotlin/org/nxcloudce/server/gateway/infrastructure/JacksonProducers.kt
@@ -1,4 +1,4 @@
-package org.nxcloudce.server.technical.producer
+package org.nxcloudce.server.gateway.infrastructure
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule

--- a/libs/server/gateway/src/main/kotlin/org/nxcloudce/server/gateway/persistence/RunRepositoryImpl.kt
+++ b/libs/server/gateway/src/main/kotlin/org/nxcloudce/server/gateway/persistence/RunRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package org.nxcloudce.server.gateway.persistence
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.smallrye.mutiny.coroutines.asFlow
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
@@ -17,19 +18,20 @@ import java.time.LocalDateTime
 @ApplicationScoped
 class RunRepositoryImpl(
   private val runPanacheRepository: RunPanacheRepository,
+  private val objectMapper: ObjectMapper,
 ) : RunRepository {
   override suspend fun create(
     run: EndRunRequest.Run,
     status: RunStatus,
     workspaceId: WorkspaceId,
   ): Run {
-    val entity = run.toEntity(status, workspaceId)
+    val entity = run.toEntity(status, workspaceId, objectMapper)
 
-    return runPanacheRepository.persist(entity).awaitSuspending().run { entity.toDomain() }
+    return runPanacheRepository.persist(entity).awaitSuspending().run { entity.toDomain(objectMapper) }
   }
 
   override fun findAllByCreationDateOlderThan(date: LocalDateTime): Flow<Run> =
-    runPanacheRepository.findAllByEndTimeLowerThan(date).asFlow().map { it.toDomain() }
+    runPanacheRepository.findAllByEndTimeLowerThan(date).asFlow().map { it.toDomain(objectMapper) }
 
   override suspend fun delete(run: Run) = runPanacheRepository.deleteById(ObjectId(run.id.value)).awaitSuspending()
 }

--- a/libs/server/gateway/src/test/kotlin/org/nxcloudce/server/gateway/persistence/RunRepositoryImplTest.kt
+++ b/libs/server/gateway/src/test/kotlin/org/nxcloudce/server/gateway/persistence/RunRepositoryImplTest.kt
@@ -78,11 +78,32 @@ class RunRepositoryImplTest {
                       type = "application",
                       name = "apps/server",
                       data =
-                        ProjectGraph.Project.Data(
+                        ProjectGraph.Project.ProjectConfiguration(
                           root = "root",
                           sourceRoot = "root",
-                          metadata = emptyMap(),
-                          targets = emptyMap(),
+                          metadata =
+                            ProjectGraph.Project.ProjectConfiguration.ProjectMetadata(
+                              description = null,
+                              technologies = null,
+                              targetGroups = null,
+                            ),
+                          targets =
+                            mapOf(
+                              "build" to
+                                ProjectGraph.Project.ProjectConfiguration.TargetConfiguration(
+                                  executor = "@nx/angular:ng-packagr-lite",
+                                  command = null,
+                                  outputs = listOf("^build", "build"),
+                                  dependsOn = null,
+                                  inputs = listOf("production", "^production"),
+                                  options = null,
+                                  configurations = null,
+                                  defaultConfiguration = null,
+                                  cache = null,
+                                  parallelism = null,
+                                  syncGenerators = null,
+                                ),
+                            ),
                         ),
                     ),
                 ),

--- a/libs/server/persistence/build.gradle.kts
+++ b/libs/server/persistence/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
   implementation(enforcedPlatform("$quarkusPlatformGroupId:$quarkusPlatformArtifactId:$quarkusPlatformVersion"))
   implementation("io.quarkus:quarkus-arc")
   implementation("io.quarkus:quarkus-kotlin")
+  implementation("io.quarkus:quarkus-liquibase-mongodb")
   implementation("io.quarkus:quarkus-mongodb-panache-kotlin")
 
   testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test")

--- a/libs/server/persistence/src/main/kotlin/org/nxcloudce/server/persistence/PersistenceCodecProvider.kt
+++ b/libs/server/persistence/src/main/kotlin/org/nxcloudce/server/persistence/PersistenceCodecProvider.kt
@@ -1,0 +1,26 @@
+package org.nxcloudce.server.persistence
+
+import ProjectCodec
+import org.bson.codecs.Codec
+import org.bson.codecs.configuration.CodecProvider
+import org.bson.codecs.configuration.CodecRegistry
+import org.nxcloudce.server.persistence.codec.ProjectConfigurationCodec
+import org.nxcloudce.server.persistence.codec.ProjectGraphCodec
+import org.nxcloudce.server.persistence.codec.ProjectMetadataCodec
+import org.nxcloudce.server.persistence.entity.RunEntity
+
+@Suppress("unused")
+class PersistenceCodecProvider : CodecProvider {
+  @Suppress("UNCHECKED_CAST")
+  override fun <T : Any> get(
+    clazz: Class<T>,
+    registry: CodecRegistry,
+  ): Codec<T>? =
+    when (clazz) {
+      RunEntity.ProjectGraph::class.java -> ProjectGraphCodec(registry) as Codec<T>
+      RunEntity.ProjectGraph.Project::class.java -> ProjectCodec(registry) as Codec<T>
+      RunEntity.ProjectGraph.Project.ProjectConfiguration::class.java -> ProjectConfigurationCodec(registry) as Codec<T>
+      RunEntity.ProjectGraph.Project.ProjectConfiguration.Metadata::class.java -> ProjectMetadataCodec() as Codec<T>
+      else -> null
+    }
+}

--- a/libs/server/persistence/src/main/kotlin/org/nxcloudce/server/persistence/codec/BsonReaderExtensions.kt
+++ b/libs/server/persistence/src/main/kotlin/org/nxcloudce/server/persistence/codec/BsonReaderExtensions.kt
@@ -1,0 +1,45 @@
+package org.nxcloudce.server.persistence.codec
+
+import org.bson.BsonReader
+import org.bson.BsonType
+
+fun BsonReader.readStringArray(): List<String> =
+  buildList {
+    readStartArray()
+    while (readBsonType() != BsonType.END_OF_DOCUMENT) {
+      add(readString())
+    }
+    readEndArray()
+  }
+
+inline fun <T> BsonReader.readRequiredField(
+  fieldName: String,
+  reader: BsonReader.() -> T,
+): T {
+  readName()
+  return reader()
+}
+
+inline fun <T> BsonReader.readNullableField(
+  fieldName: String,
+  reader: BsonReader.() -> T,
+): T? {
+  readName()
+  return when (currentBsonType) {
+    BsonType.NULL -> {
+      readNull()
+      null
+    }
+    else -> reader()
+  }
+}
+
+inline fun <T> BsonReader.readDocumentMap(valueReader: BsonReader.() -> T): Map<String, T> =
+  buildMap {
+    readStartDocument()
+    while (readBsonType() != BsonType.END_OF_DOCUMENT) {
+      val key = readName()
+      put(key, valueReader())
+    }
+    readEndDocument()
+  }

--- a/libs/server/persistence/src/main/kotlin/org/nxcloudce/server/persistence/codec/BsonWriterExtensions.kt
+++ b/libs/server/persistence/src/main/kotlin/org/nxcloudce/server/persistence/codec/BsonWriterExtensions.kt
@@ -1,0 +1,38 @@
+package org.nxcloudce.server.persistence.codec
+
+import org.bson.BsonWriter
+
+inline fun BsonWriter.writeRequiredField(
+  fieldName: String,
+  writer: BsonWriter.() -> Unit,
+) {
+  writeName(fieldName)
+  writer()
+}
+
+fun <T> BsonWriter.writeNullableField(
+  fieldName: String,
+  value: T?,
+  writer: BsonWriter.(T) -> Unit,
+) {
+  writeName(fieldName)
+  value?.let { writer(it) } ?: writeNull()
+}
+
+inline fun BsonWriter.writeArrayField(writer: BsonWriter.() -> Unit) {
+  writeStartArray()
+  writer()
+  writeEndArray()
+}
+
+inline fun <T> BsonWriter.writeDocumentMap(
+  map: Map<String, T>,
+  crossinline valueWriter: BsonWriter.(T) -> Unit,
+) {
+  writeStartDocument()
+  map.forEach { (key, value) ->
+    writeName(key)
+    valueWriter(value)
+  }
+  writeEndDocument()
+}

--- a/libs/server/persistence/src/main/kotlin/org/nxcloudce/server/persistence/codec/ProjectCodec.kt
+++ b/libs/server/persistence/src/main/kotlin/org/nxcloudce/server/persistence/codec/ProjectCodec.kt
@@ -1,0 +1,64 @@
+import org.bson.BsonReader
+import org.bson.BsonWriter
+import org.bson.codecs.Codec
+import org.bson.codecs.DecoderContext
+import org.bson.codecs.EncoderContext
+import org.bson.codecs.configuration.CodecRegistry
+import org.nxcloudce.server.persistence.codec.readRequiredField
+import org.nxcloudce.server.persistence.codec.writeRequiredField
+import org.nxcloudce.server.persistence.entity.RunEntity
+
+class ProjectCodec(private val registry: CodecRegistry) : Codec<RunEntity.ProjectGraph.Project> {
+  private val configurationCodec by lazy {
+    registry[RunEntity.ProjectGraph.Project.ProjectConfiguration::class.java]
+  }
+
+  override fun encode(
+    writer: BsonWriter,
+    value: RunEntity.ProjectGraph.Project,
+    encoderContext: EncoderContext,
+  ) = writer.run {
+    writeStartDocument()
+    writeFields(value, encoderContext)
+    writeEndDocument()
+  }
+
+  private fun BsonWriter.writeFields(
+    value: RunEntity.ProjectGraph.Project,
+    encoderContext: EncoderContext,
+  ) {
+    writeString("type", value.type)
+    writeString("name", value.name)
+    writeRequiredField("data") {
+      configurationCodec.encode(this, value.data, encoderContext)
+    }
+  }
+
+  override fun decode(
+    reader: BsonReader,
+    decoderContext: DecoderContext,
+  ): RunEntity.ProjectGraph.Project =
+    reader.run {
+      readStartDocument()
+      val project = readProjectFields(decoderContext)
+      readEndDocument()
+      project
+    }
+
+  private fun BsonReader.readProjectFields(decoderContext: DecoderContext): RunEntity.ProjectGraph.Project {
+    val type = readRequiredField("type") { readString() }
+    val name = readRequiredField("name") { readString() }
+    val data =
+      readRequiredField("data") {
+        configurationCodec.decode(this, decoderContext)
+      }
+
+    return RunEntity.ProjectGraph.Project(
+      type = type,
+      name = name,
+      data = data,
+    )
+  }
+
+  override fun getEncoderClass(): Class<RunEntity.ProjectGraph.Project> = RunEntity.ProjectGraph.Project::class.java
+}

--- a/libs/server/persistence/src/main/kotlin/org/nxcloudce/server/persistence/codec/ProjectConfigurationCodec.kt
+++ b/libs/server/persistence/src/main/kotlin/org/nxcloudce/server/persistence/codec/ProjectConfigurationCodec.kt
@@ -1,0 +1,83 @@
+package org.nxcloudce.server.persistence.codec
+
+import org.bson.BsonReader
+import org.bson.BsonType
+import org.bson.BsonWriter
+import org.bson.codecs.Codec
+import org.bson.codecs.DecoderContext
+import org.bson.codecs.EncoderContext
+import org.bson.codecs.configuration.CodecRegistry
+import org.nxcloudce.server.persistence.entity.RunEntity
+
+class ProjectConfigurationCodec(private val registry: CodecRegistry) :
+  Codec<RunEntity.ProjectGraph.Project.ProjectConfiguration> {
+  private val metadataCodec by lazy {
+    registry[RunEntity.ProjectGraph.Project.ProjectConfiguration.Metadata::class.java]
+  }
+
+  override fun encode(
+    writer: BsonWriter,
+    value: RunEntity.ProjectGraph.Project.ProjectConfiguration,
+    encoderContext: EncoderContext,
+  ) = writer.run {
+    writeStartDocument()
+    writeFields(value, encoderContext)
+    writeEndDocument()
+  }
+
+  private fun BsonWriter.writeFields(
+    value: RunEntity.ProjectGraph.Project.ProjectConfiguration,
+    encoderContext: EncoderContext,
+  ) {
+    writeString("root", value.root)
+    writeNullableField("sourceRoot", value.sourceRoot) { writeString(it) }
+    writeNullableField("targets", value.targets) { targets ->
+      writeStartDocument()
+      targets.forEach { (group, target) -> writeString(group, target) }
+      writeEndDocument()
+    }
+    writeNullableField("metadata", value.metadata) { metadata ->
+      metadataCodec.encode(this, metadata, encoderContext)
+    }
+  }
+
+  override fun decode(
+    reader: BsonReader,
+    decoderContext: DecoderContext?,
+  ): RunEntity.ProjectGraph.Project.ProjectConfiguration =
+    reader.run {
+      readStartDocument()
+      val configuration = readConfigurationFields(decoderContext)
+      readEndDocument()
+      configuration
+    }
+
+  private fun BsonReader.readConfigurationFields(decoderContext: DecoderContext?): RunEntity.ProjectGraph.Project.ProjectConfiguration {
+    val root = readRequiredField("root") { readString() }
+    val sourceRoot = readNullableField("sourceRoot") { readString() }
+    val targets = readNullableField("targets") { readTargetMappings() }
+    val metadata =
+      readNullableField("metadata") {
+        metadataCodec.decode(this, decoderContext)
+      }
+
+    return RunEntity.ProjectGraph.Project.ProjectConfiguration(
+      root = root,
+      sourceRoot = sourceRoot,
+      targets = targets,
+      metadata = metadata,
+    )
+  }
+
+  private fun BsonReader.readTargetMappings(): Map<String, String> =
+    buildMap {
+      readStartDocument()
+      while (readBsonType() != BsonType.END_OF_DOCUMENT) {
+        put(readName(), readString())
+      }
+      readEndDocument()
+    }
+
+  override fun getEncoderClass(): Class<RunEntity.ProjectGraph.Project.ProjectConfiguration> =
+    RunEntity.ProjectGraph.Project.ProjectConfiguration::class.java
+}

--- a/libs/server/persistence/src/main/kotlin/org/nxcloudce/server/persistence/codec/ProjectGraphCodec.kt
+++ b/libs/server/persistence/src/main/kotlin/org/nxcloudce/server/persistence/codec/ProjectGraphCodec.kt
@@ -1,0 +1,104 @@
+package org.nxcloudce.server.persistence.codec
+
+import org.bson.BsonReader
+import org.bson.BsonType
+import org.bson.BsonWriter
+import org.bson.codecs.Codec
+import org.bson.codecs.DecoderContext
+import org.bson.codecs.EncoderContext
+import org.bson.codecs.configuration.CodecRegistry
+import org.nxcloudce.server.persistence.entity.RunEntity
+
+class ProjectGraphCodec(private val registry: CodecRegistry) : Codec<RunEntity.ProjectGraph> {
+  private val projectCodec by lazy {
+    registry[RunEntity.ProjectGraph.Project::class.java]
+  }
+
+  override fun encode(
+    writer: BsonWriter,
+    value: RunEntity.ProjectGraph,
+    encoderContext: EncoderContext,
+  ) = writer.run {
+    writeStartDocument()
+    writeFields(value, encoderContext)
+    writeEndDocument()
+  }
+
+  private fun BsonWriter.writeFields(
+    value: RunEntity.ProjectGraph,
+    encoderContext: EncoderContext,
+  ) {
+    writeRequiredField("nodes") {
+      writeDocumentMap(value.nodes) { project ->
+        projectCodec.encode(this, project, encoderContext)
+      }
+    }
+
+    writeRequiredField("dependencies") {
+      writeDocumentMap(value.dependencies) { deps ->
+        writeStartArray()
+        deps.forEach { writeDependency(it) }
+        writeEndArray()
+      }
+    }
+  }
+
+  private fun BsonWriter.writeDependency(dependency: RunEntity.ProjectGraph.Dependency) {
+    writeStartDocument()
+    writeString("source", dependency.source)
+    writeString("target", dependency.target)
+    writeString("type", dependency.type)
+    writeEndDocument()
+  }
+
+  override fun decode(
+    reader: BsonReader,
+    decoderContext: DecoderContext,
+  ): RunEntity.ProjectGraph =
+    reader.run {
+      readStartDocument()
+      val graph = readGraphFields(decoderContext)
+      readEndDocument()
+      graph
+    }
+
+  private fun BsonReader.readGraphFields(decoderContext: DecoderContext): RunEntity.ProjectGraph {
+    val nodes =
+      readRequiredField("nodes") {
+        readDocumentMap { projectCodec.decode(this, decoderContext) }
+      }
+
+    val dependencies =
+      readRequiredField("dependencies") {
+        readDocumentMap { readDependenciesList() }
+      }
+
+    return RunEntity.ProjectGraph(
+      nodes = nodes,
+      dependencies = dependencies,
+    )
+  }
+
+  private fun BsonReader.readDependenciesList(): List<RunEntity.ProjectGraph.Dependency> =
+    buildList {
+      readStartArray()
+      while (readBsonType() != BsonType.END_OF_DOCUMENT) {
+        add(readDependency())
+      }
+      readEndArray()
+    }
+
+  private fun BsonReader.readDependency(): RunEntity.ProjectGraph.Dependency {
+    readStartDocument()
+    val dependency =
+      RunEntity.ProjectGraph.Dependency(
+        source = readRequiredField("source") { readString() },
+        target = readRequiredField("target") { readString() },
+        type = readRequiredField("type") { readString() },
+      )
+    readEndDocument()
+    return dependency
+  }
+
+  override fun getEncoderClass(): Class<RunEntity.ProjectGraph> = RunEntity.ProjectGraph::class.java
+}

--- a/libs/server/persistence/src/main/kotlin/org/nxcloudce/server/persistence/codec/ProjectMetadataCodec.kt
+++ b/libs/server/persistence/src/main/kotlin/org/nxcloudce/server/persistence/codec/ProjectMetadataCodec.kt
@@ -1,0 +1,71 @@
+package org.nxcloudce.server.persistence.codec
+
+import org.bson.BsonReader
+import org.bson.BsonType
+import org.bson.BsonWriter
+import org.bson.codecs.Codec
+import org.bson.codecs.DecoderContext
+import org.bson.codecs.EncoderContext
+import org.nxcloudce.server.persistence.entity.RunEntity
+
+class ProjectMetadataCodec : Codec<RunEntity.ProjectGraph.Project.ProjectConfiguration.Metadata> {
+  override fun encode(
+    writer: BsonWriter,
+    value: RunEntity.ProjectGraph.Project.ProjectConfiguration.Metadata,
+    encoderContext: EncoderContext,
+  ) = writer.run {
+    writeStartDocument()
+    writeFields(value)
+    writeEndDocument()
+  }
+
+  private fun BsonWriter.writeFields(value: RunEntity.ProjectGraph.Project.ProjectConfiguration.Metadata) {
+    writeNullableField("description", value.description) { writeString(it) }
+    writeNullableField("technologies", value.technologies) { technologies ->
+      writeArrayField { technologies.forEach { writeString(it) } }
+    }
+    writeNullableField("targetGroups", value.targetGroups) { groups ->
+      writeStartDocument()
+      groups.forEach { (group, targets) ->
+        writeName(group)
+        writeArrayField { targets.forEach { writeString(it) } }
+      }
+      writeEndDocument()
+    }
+  }
+
+  override fun decode(
+    reader: BsonReader,
+    decoderContext: DecoderContext,
+  ): RunEntity.ProjectGraph.Project.ProjectConfiguration.Metadata =
+    reader.run {
+      readStartDocument()
+      val metadata = readMetadataFields()
+      readEndDocument()
+      metadata
+    }
+
+  private fun BsonReader.readMetadataFields(): RunEntity.ProjectGraph.Project.ProjectConfiguration.Metadata {
+    val description = readNullableField("description") { readString() }
+    val technologies = readNullableField("technologies") { readStringArray() }
+    val targetGroups = readNullableField("targetGroups") { readTargetGroups() }
+    return RunEntity.ProjectGraph.Project.ProjectConfiguration.Metadata(
+      description,
+      technologies,
+      targetGroups,
+    )
+  }
+
+  private fun BsonReader.readTargetGroups(): Map<String, Collection<String>> =
+    buildMap {
+      readStartDocument()
+      while (readBsonType() != BsonType.END_OF_DOCUMENT) {
+        val groupName = readName()
+        put(groupName, readStringArray())
+      }
+      readEndDocument()
+    }
+
+  override fun getEncoderClass(): Class<RunEntity.ProjectGraph.Project.ProjectConfiguration.Metadata> =
+    RunEntity.ProjectGraph.Project.ProjectConfiguration.Metadata::class.java
+}

--- a/libs/server/persistence/src/main/kotlin/org/nxcloudce/server/persistence/entity/RunEntity.kt
+++ b/libs/server/persistence/src/main/kotlin/org/nxcloudce/server/persistence/entity/RunEntity.kt
@@ -49,40 +49,31 @@ data class RunEntity(
     var platformName: String?,
   )
 
-  // TODO: we should not use `val`, otherwise, values can't be late-initialized
-  // https://github.com/clementguillot/nx-cloud-ce/issues/118
   @MongoEntity
   data class ProjectGraph(
-    val nodes: Map<String, Project>,
-    val dependencies: Map<String, List<Dependency>>,
+    var nodes: Map<String, Project>,
+    var dependencies: Map<String, List<Dependency>>,
   ) {
     @MongoEntity
     data class Project(
       var type: String,
       var name: String,
-      var data: Data,
+      var data: ProjectConfiguration,
     ) {
       @MongoEntity
-      data class Data(
+      data class ProjectConfiguration(
         var root: String,
         var sourceRoot: String?,
-        // TODO: can't implement those field due to missing custom codec
-        // https://github.com/clementguillot/nx-cloud-ce/issues/118
-        // var metadata: Map<String, Any>?,
-        // var targets: Map<String, Target>,
+        var targets: Map<String, String>?,
+        var metadata: Metadata?,
       ) {
-        // @MongoEntity
-        // data class Target(
-        //   val executor: String?,
-        //   val dependsOn: Collection<String>?,
-        //   val options: Map<String, Any>?,
-        //   val configurations: Any?,
-        //   val parallelism: Boolean?,
-        //   val inputs: Collection<Any>?,
-        //   val outputs: Collection<String>?,
-        //   val defaultConfiguration: String?,
-        //   val cache: Boolean?,
-        // )
+        @MongoEntity
+        data class Metadata(
+          var description: String?,
+          var technologies: Collection<String>?,
+          var targetGroups: Map<String, Collection<String>>?,
+          // missing `owners?`
+        )
       }
     }
 

--- a/libs/server/persistence/src/main/resources/db/change-log.yaml
+++ b/libs/server/persistence/src/main/resources/db/change-log.yaml
@@ -1,0 +1,4 @@
+databaseChangeLog:
+  - include:
+      relativeToChangelogFile: true
+      file: changes/1730584515585-set-run-project-graph-null.yaml

--- a/libs/server/persistence/src/main/resources/db/changes/1730584515585-set-run-project-graph-null.yaml
+++ b/libs/server/persistence/src/main/resources/db/changes/1730584515585-set-run-project-graph-null.yaml
@@ -1,0 +1,17 @@
+databaseChangeLog:
+  - changeSet:
+      id: 1730584515585-1
+      author: clementguillot
+      changes:
+        - runCommand:
+            command: |
+              {
+                update: "run",
+                updates: [
+                  {
+                    q: {},
+                    u: { $set: { projectGraph: null } },
+                    multi: true
+                  }
+                ]
+              }

--- a/libs/server/persistence/src/test/kotlin/org/nxcloudce/server/persistence/repository/RunPanacheRepositoryTest.kt
+++ b/libs/server/persistence/src/test/kotlin/org/nxcloudce/server/persistence/repository/RunPanacheRepositoryTest.kt
@@ -88,16 +88,33 @@ class RunPanacheRepositoryTest {
         RunEntity.ProjectGraph(
           nodes =
             mapOf(
-              "node" to
+              "node1" to
                 RunEntity.ProjectGraph.Project(
                   type = "test type",
                   name = "test name",
                   data =
-                    RunEntity.ProjectGraph.Project.Data(
+                    RunEntity.ProjectGraph.Project.ProjectConfiguration(
                       root = "root",
-                      sourceRoot = "root",
-                      // metadata = emptyMap(),
-                      // targets = emptyMap(),
+                      sourceRoot = "source root",
+                      targets = mapOf("target" to "{target}"),
+                      metadata =
+                        RunEntity.ProjectGraph.Project.ProjectConfiguration.Metadata(
+                          description = "description",
+                          technologies = listOf("technologies"),
+                          targetGroups = mapOf("target" to listOf("group")),
+                        ),
+                    ),
+                ),
+              "node2" to
+                RunEntity.ProjectGraph.Project(
+                  type = "test type",
+                  name = "test name",
+                  data =
+                    RunEntity.ProjectGraph.Project.ProjectConfiguration(
+                      root = "root",
+                      sourceRoot = null,
+                      metadata = null,
+                      targets = null,
                     ),
                 ),
             ),


### PR DESCRIPTION
- Fixes #118 
- BREAKING CHANGE: add a Liquibase migration to null previous `ProjectGraph` (from `Run` collection). **Liquibase requires a database different than `admin` w/ `dbAdmin` role!**
- Update `mongodb` sub-chart values to add an init script to grant `dbAdmin` role to `server` user